### PR TITLE
Se agrega la propiedad timestamps: false a los modelos

### DIFF
--- a/back/models/country.model.js
+++ b/back/models/country.model.js
@@ -11,12 +11,8 @@ module.exports = (sequelize, DataTypes) => {
     country: DataTypes.STRING,
   }, {
     sequelize,
+    timestamps: false,
     tableName: COUNTRIES_TABLE_NAME,
-    defaultScope: {
-      attributes: {
-        exclude: ['deletedAt', 'createdAt', 'updatedAt'],
-      },
-    },
   });
   return Country;
 };

--- a/back/models/experience.model.js
+++ b/back/models/experience.model.js
@@ -26,12 +26,8 @@ module.exports = (sequelize, DataTypes) => {
     description: DataTypes.STRING,
   }, {
     sequelize,
+    timestamps: false,
     tableName: EXPERIENCES_TABLE_NAME,
-    defaultScope: {
-      attributes: {
-        exclude: ['deletedAt', 'createdAt', 'updatedAt'],
-      },
-    },
   });
   return Experience;
 };

--- a/back/models/experience_status.model.js
+++ b/back/models/experience_status.model.js
@@ -11,12 +11,8 @@ module.exports = (sequelize, DataTypes) => {
     status: DataTypes.STRING,
   }, {
     sequelize,
+    timestamps: false,
     tableName: EXPERIENCES_STATUS_TABLE_NAME,
-    defaultScope: {
-      attributes: {
-        exclude: ['deletedAt', 'createdAt', 'updatedAt'],
-      },
-    },
   });
   return ExperienceStatus;
 };

--- a/back/models/experience_type.model.js
+++ b/back/models/experience_type.model.js
@@ -11,12 +11,8 @@ module.exports = (sequelize, DataTypes) => {
     type: DataTypes.STRING,
   }, {
     sequelize,
+    timestamps: false,
     tableName: EXPERIENCES_TYPES_TABLE_NAME,
-    defaultScope: {
-      attributes: {
-        exclude: ['deletedAt', 'createdAt', 'updatedAt'],
-      },
-    },
   });
   return ExpirenceType;
 };

--- a/back/models/formation.model.js
+++ b/back/models/formation.model.js
@@ -24,12 +24,8 @@ module.exports = (sequelize, DataTypes) => {
     description: DataTypes.STRING,
   }, {
     sequelize,
+    timestamps: false,
     tableName: FORMATIONS_TABLE_NAME,
-    defaultScope: {
-      attributes: {
-        exclude: ['deletedAt', 'createdAt', 'updatedAt'],
-      },
-    },
   });
   return Formation;
 };

--- a/back/models/formation_status.model.js
+++ b/back/models/formation_status.model.js
@@ -11,12 +11,8 @@ module.exports = (sequelize, DataTypes) => {
     status: DataTypes.STRING,
   }, {
     sequelize,
+    timestamps: false,
     tableName: FORMATIONS_STATUS_TABLE_NAME,
-    defaultScope: {
-      attributes: {
-        exclude: ['deletedAt', 'createdAt', 'updatedAt'],
-      },
-    },
   });
   return FormationStatus;
 };

--- a/back/models/formation_type.model.js
+++ b/back/models/formation_type.model.js
@@ -11,12 +11,8 @@ module.exports = (sequelize, DataTypes) => {
     type: DataTypes.STRING,
   }, {
     sequelize,
+    timestamps: false,
     tableName: FORMATIONS_TYPES_TABLE_NAME,
-    defaultScope: {
-      attributes: {
-        exclude: ['deletedAt', 'createdAt', 'updatedAt'],
-      },
-    },
   });
   return FormationType;
 };

--- a/back/models/language.model.js
+++ b/back/models/language.model.js
@@ -18,12 +18,8 @@ module.exports = (sequelize, DataTypes) => {
     language: DataTypes.STRING,
   }, {
     sequelize,
+    timestamps: false,
     tableName: LANGUAGES_TABLE_NAME,
-    defaultScope: {
-      attributes: {
-        exclude: ['deletedAt', 'createdAt', 'updatedAt'],
-      },
-    },
   });
   return Language;
 };

--- a/back/models/marital.model.js
+++ b/back/models/marital.model.js
@@ -11,12 +11,8 @@ module.exports = (sequelize, DataTypes) => {
     condition: DataTypes.STRING,
   }, {
     sequelize,
+    timestamps: false,
     tableName: MARITALS_TABLE_NAME,
-    defaultScope: {
-      attributes: {
-        exclude: ['deletedAt', 'createdAt', 'updatedAt'],
-      },
-    },
   });
   return Marital;
 };

--- a/back/models/optional.model.js
+++ b/back/models/optional.model.js
@@ -34,12 +34,8 @@ module.exports = (sequelize, DataTypes) => {
     zipCode: DataTypes.STRING,
   }, {
     sequelize,
+    timestamps: false,
     tableName: OPTIONALS_TABLE_NAME,
-    defaultScope: {
-      attributes: {
-        exclude: ['deletedAt', 'createdAt', 'updatedAt'],
-      },
-    },
   });
   return Optional;
 };

--- a/back/models/profile.model.js
+++ b/back/models/profile.model.js
@@ -51,12 +51,8 @@ module.exports = (sequelize, DataTypes) => {
     profileName: DataTypes.STRING,
   }, {
     sequelize,
+    timestamps: false,
     tableName: PROFILES_TABLE_NAME,
-    defaultScope: {
-      attributes: {
-        exclude: ['deletedAt', 'createdAt', 'updatedAt'],
-      },
-    },
   });
   return Profile;
 };

--- a/back/models/profile_experience.model.js
+++ b/back/models/profile_experience.model.js
@@ -14,11 +14,6 @@ module.exports = (sequelize, DataTypes) => {
     sequelize,
     timestamps: false,
     tableName: PROFILES_EXPERIENCES_TABLE_NAME,
-    defaultScope: {
-      attributes: {
-        exclude: ['deletedAt', 'createdAt', 'updatedAt'],
-      },
-    },
   });
   return ProfileExperience;
 };

--- a/back/models/profile_formation.model.js
+++ b/back/models/profile_formation.model.js
@@ -14,11 +14,6 @@ module.exports = (sequelize, DataTypes) => {
     sequelize,
     timestamps: false,
     tableName: PROFILES_FORMATIONS_TABLE_NAME,
-    defaultScope: {
-      attributes: {
-        exclude: ['deletedAt', 'createdAt', 'updatedAt'],
-      },
-    },
   });
   return ProfileFormation;
 };

--- a/back/models/profile_language.model.js
+++ b/back/models/profile_language.model.js
@@ -15,11 +15,6 @@ module.exports = (sequelize, DataTypes) => {
     sequelize,
     timestamps: false,
     tableName: PROFILES_LANGUAGES_TABLE_NAME,
-    defaultScope: {
-      attributes: {
-        exclude: ['deletedAt', 'createdAt', 'updatedAt'],
-      },
-    },
   });
   return ProfileLanguage;
 };

--- a/back/models/profile_optional.model.js
+++ b/back/models/profile_optional.model.js
@@ -14,12 +14,6 @@ module.exports = (sequelize, DataTypes) => {
     sequelize,
     timestamps: false,
     tableName: PROFILES_OPTIONALS_TABLE_NAME,
-    defaultScope: {
-      attributes: {
-        exclude: ['deletedAt', 'createdAt', 'updatedAt'],
-      },
-    },
-
   });
   return ProfileOptional;
 };

--- a/back/models/profile_reference.model.js
+++ b/back/models/profile_reference.model.js
@@ -14,11 +14,6 @@ module.exports = (sequelize, DataTypes) => {
     sequelize,
     timestamps: false,
     tableName: PROFILES_REFERENCES_TABLE_NAME,
-    defaultScope: {
-      attributes: {
-        exclude: ['deletedAt', 'createdAt', 'updatedAt'],
-      },
-    },
   });
   return ProfileReference;
 };

--- a/back/models/profile_skill.model.js
+++ b/back/models/profile_skill.model.js
@@ -15,11 +15,6 @@ module.exports = (sequelize, DataTypes) => {
     sequelize,
     timestamps: false,
     tableName: PROFILES_SKILLS_TABLE_NAME,
-    defaultScope: {
-      attributes: {
-        exclude: ['deletedAt', 'createdAt', 'updatedAt'],
-      },
-    },
   });
   return ProfileSkill;
 };

--- a/back/models/reference.model.js
+++ b/back/models/reference.model.js
@@ -15,12 +15,8 @@ module.exports = (sequelize, DataTypes) => {
     company: DataTypes.STRING,
   }, {
     sequelize,
+    timestamps: false,
     tableName: REFERENCES_TABLE_NAME,
-    defaultScope: {
-      attributes: {
-        exclude: ['deletedAt', 'createdAt', 'updatedAt'],
-      },
-    },
   });
   return Reference;
 };

--- a/back/models/roles.model.js
+++ b/back/models/roles.model.js
@@ -14,12 +14,8 @@ module.exports = (sequelize, DataTypes) => {
     rol: DataTypes.STRING,
   }, {
     sequelize,
+    timestamps: false,
     tableName: ROLES_TABLE_NAME,
-    defaultScope: {
-      attributes: {
-        exclude: ['deletedAt', 'createdAt', 'updatedAt'],
-      },
-    },
   });
   return Rol;
 };

--- a/back/models/sex.model.js
+++ b/back/models/sex.model.js
@@ -11,12 +11,8 @@ module.exports = (sequelize, DataTypes) => {
     gender: DataTypes.STRING,
   }, {
     sequelize,
+    timestamps: false,
     tableName: SEXS_TABLE_NAME,
-    defaultScope: {
-      attributes: {
-        exclude: ['deletedAt', 'createdAt', 'updatedAt'],
-      },
-    },
   });
   return Sex;
 };

--- a/back/models/skill.model.js
+++ b/back/models/skill.model.js
@@ -11,12 +11,8 @@ module.exports = (sequelize, DataTypes) => {
     skill: DataTypes.STRING,
   }, {
     sequelize,
+    timestamps: false,
     tableName: SKILLS_TABLE_NAME,
-    defaultScope: {
-      attributes: {
-        exclude: ['deletedAt', 'createdAt', 'updatedAt'],
-      },
-    },
   });
   return Skill;
 };

--- a/back/models/user.model.js
+++ b/back/models/user.model.js
@@ -27,12 +27,8 @@ module.exports = (sequelize, DataTypes) => {
     pictureLink: DataTypes.STRING,
   }, {
     sequelize,
+    timestamps: false,
     tableName: USERS_TABLE_NAME,
-    defaultScope: {
-      attributes: {
-        exclude: ['deletedAt', 'createdAt', 'updatedAt'],
-      },
-    },
   });
   return User;
 };


### PR DESCRIPTION
Se intentó deshabilitar globalmente la generación automática de atributos de fecha y hora (timestamps) al instanciar sequelize en el archivo de configuración sequelize.config.js.
```
define: {
    timestamps: false,
},
```
 Sin embargo, esta configuración no tuvo el efecto deseado. Por lo tanto, se optó por utilizar la propiedad `timestamps: false` en cada uno de los modelos para desactivar los timestamps individualmente.